### PR TITLE
feat(server): add configurable server timeout and name parameters

### DIFF
--- a/mcp/server/__init__.py
+++ b/mcp/server/__init__.py
@@ -1,1 +1,5 @@
 """MCP server package."""
+
+from .server import Server
+
+__all__ = ["Server"]

--- a/mcp/server/doodle_server.py
+++ b/mcp/server/doodle_server.py
@@ -10,9 +10,13 @@ logger = setup_logger("DoodleServer")
 class DoodleServer(Server):
     """MCP Server that provides dog-related functionality"""
 
-    def __init__(self):
-        """Initialize the doodle server."""
-        super().__init__()
+    def __init__(self, name: str = "doodle"):
+        """Initialize the doodle server.
+        
+        Args:
+            name: The name of the server instance
+        """
+        super().__init__(name=name)
         self.last_bark: Optional[datetime] = None
 
     async def bark(self, intensity: str = "normal") -> Dict[str, str]:

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -1,6 +1,10 @@
 class Server:
     """Base server class for all server implementations."""
-    
-    def __init__(self):
-        """Initialize the base server."""
-        pass 
+
+    def __init__(self, name: str = "unnamed"):
+        """Initialize the base server.
+
+        Args:
+            name: The name of the server instance
+        """
+        self.name = name

--- a/mcp_registry/__main__.py
+++ b/mcp_registry/__main__.py
@@ -8,9 +8,11 @@ async def main():
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="MCP Registry Server")
     parser.add_argument("--name", default="registry", help="Name of the registry server")
+    parser.add_argument("--timeout", type=int, default=60, 
+                       help="Server timeout in seconds (default: 60)")
     args = parser.parse_args()
     
-    server = RegistryServer(name=args.name)
+    server = RegistryServer(name=args.name, server_timeout_seconds=args.timeout)
     server._cleanup_task = asyncio.create_task(server._cleanup_loop())
     
     async with stdio_server() as (read_stream, write_stream):

--- a/mcp_registry/server.py
+++ b/mcp_registry/server.py
@@ -3,18 +3,22 @@ from typing import Dict, List, Optional
 from datetime import datetime
 import asyncio
 import logging
-from mcp.server import Server
+from mcp.server.server import Server
+
 
 class RegistryError(Exception):
     """Base error class for MCP Registry"""
+
     def __init__(self, code: str, message: str):
         self.code = code
         self.message = message
         super().__init__(message)
 
+
 @dataclass
 class RegisteredServer:
     """Represents a registered MCP server"""
+
     id: str
     name: str
     description: str
@@ -23,31 +27,36 @@ class RegisteredServer:
     last_heartbeat: datetime
     metadata: Dict[str, str]
 
+
 class RegistryServer(Server):
     """MCP Registry Server for publishing and discovering MCP servers"""
-    
-    def __init__(self, name: str = "registry"):
+
+    def __init__(self, name: str = "registry", server_timeout_seconds: int = 60):
         super().__init__(name=name)
         self.servers: Dict[str, RegisteredServer] = {}
         self.logger = logging.getLogger("mcp.registry")
         self._cleanup_task: Optional[asyncio.Task] = None
+        self.server_timeout_seconds = server_timeout_seconds
         self.tools = {
             "register_server": self.register_server,
             "heartbeat": self.heartbeat,
             "discover_servers": self.discover_servers,
         }
 
-    async def register_server(self, 
+    async def register_server(
+        self,
         server_id: str,
         name: str,
         description: str,
         capabilities: List[str],
         endpoint: str,
-        metadata: Dict[str, str] = None
+        metadata: Dict[str, str] = None,
     ) -> Dict[str, str]:
         """Register a new MCP server with the registry"""
         if server_id in self.servers:
-            raise RegistryError("server_exists", f"Server {server_id} already registered")
+            raise RegistryError(
+                "server_exists", f"Server {server_id} already registered"
+            )
 
         self.servers[server_id] = RegisteredServer(
             id=server_id,
@@ -56,35 +65,39 @@ class RegistryServer(Server):
             capabilities=capabilities,
             endpoint=endpoint,
             last_heartbeat=datetime.utcnow(),
-            metadata=metadata or {}
+            metadata=metadata or {},
         )
-        
+
         self.logger.info(f"Registered new server: {server_id}")
         return {"status": "registered", "server_id": server_id}
 
     async def heartbeat(self, server_id: str) -> Dict[str, str]:
         """Update server heartbeat timestamp"""
         if server_id not in self.servers:
-            raise RegistryError("server_not_found", f"Server {server_id} not registered")
-            
+            raise RegistryError(
+                "server_not_found", f"Server {server_id} not registered"
+            )
+
         self.servers[server_id].last_heartbeat = datetime.utcnow()
         return {"status": "ok"}
 
-    async def discover_servers(self, 
-        capability: Optional[str] = None
+    async def discover_servers(
+        self, capability: Optional[str] = None
     ) -> List[Dict[str, str]]:
         """Discover available MCP servers, optionally filtered by capability"""
         servers = []
         for server in self.servers.values():
             if capability and capability not in server.capabilities:
                 continue
-            servers.append({
-                "id": server.id,
-                "name": server.name,
-                "description": server.description,
-                "capabilities": server.capabilities,
-                "endpoint": server.endpoint
-            })
+            servers.append(
+                {
+                    "id": server.id,
+                    "name": server.name,
+                    "description": server.description,
+                    "capabilities": server.capabilities,
+                    "endpoint": server.endpoint,
+                }
+            )
         return servers
 
     async def _cleanup_loop(self):
@@ -93,15 +106,19 @@ class RegistryServer(Server):
             try:
                 now = datetime.utcnow()
                 stale_servers = [
-                    server_id for server_id, server in self.servers.items()
-                    if (now - server.last_heartbeat).total_seconds() > 60
+                    server_id
+                    for server_id, server in self.servers.items()
+                    if (now - server.last_heartbeat).total_seconds()
+                    > self.server_timeout_seconds
                 ]
-                
+
                 for server_id in stale_servers:
                     del self.servers[server_id]
-                    self.logger.info(f"Removed stale server: {server_id}")
-                    
-                await asyncio.sleep(30)
+                    self.logger.info(
+                        f"Removed stale server: {server_id} (timeout: {self.server_timeout_seconds}s)"
+                    )
+
+                await asyncio.sleep(min(30, self.server_timeout_seconds / 2))
             except asyncio.CancelledError:
                 break
             except Exception as e:

--- a/mcp_registry/server.py
+++ b/mcp_registry/server.py
@@ -118,7 +118,7 @@ class RegistryServer(Server):
                         f"Removed stale server: {server_id} (timeout: {self.server_timeout_seconds}s)"
                     )
 
-                await asyncio.sleep(min(30, self.server_timeout_seconds / 2))
+                await asyncio.sleep(max(5, min(30, self.server_timeout_seconds / 2)))
             except asyncio.CancelledError:
                 break
             except Exception as e:

--- a/tests/test_registry_server.py
+++ b/tests/test_registry_server.py
@@ -1,0 +1,97 @@
+import pytest
+from datetime import datetime, timedelta
+import asyncio
+from mcp_registry.server import RegistryServer
+
+@pytest.mark.asyncio
+async def test_registry_server_custom_timeout():
+    # Initialize server with 2 second timeout
+    server = RegistryServer(name="test_registry", server_timeout_seconds=2)
+    
+    # Register a test server
+    result = await server.register_server(
+        server_id="test_server",
+        name="Test Server",
+        description="Test server for timeout",
+        capabilities=["test"],
+        endpoint="test://endpoint"
+    )
+    assert result["status"] == "registered"
+    
+    # Verify server is discoverable
+    servers = await server.discover_servers()
+    assert len(servers) == 1
+    assert servers[0]["id"] == "test_server"
+    
+    # Wait for timeout period
+    await asyncio.sleep(3)  # Wait longer than timeout
+    
+    # Start cleanup
+    cleanup_task = asyncio.create_task(server._cleanup_loop())
+    await asyncio.sleep(0.1)  # Allow cleanup to run
+    
+    # Verify server was removed
+    servers = await server.discover_servers()
+    assert len(servers) == 0
+    
+    # Cleanup
+    cleanup_task.cancel()
+    try:
+        await cleanup_task
+    except asyncio.CancelledError:
+        pass
+
+@pytest.mark.asyncio
+async def test_registry_server_heartbeat_prevents_timeout():
+    # Initialize server with 2 second timeout
+    server = RegistryServer(name="test_registry", server_timeout_seconds=2)
+    
+    # Register a test server
+    await server.register_server(
+        server_id="test_server",
+        name="Test Server",
+        description="Test server for timeout",
+        capabilities=["test"],
+        endpoint="test://endpoint"
+    )
+    
+    # Start cleanup task
+    cleanup_task = asyncio.create_task(server._cleanup_loop())
+    
+    # Send heartbeats every second for 3 seconds
+    for _ in range(3):
+        await asyncio.sleep(1)
+        await server.heartbeat("test_server")
+    
+    # Verify server is still registered
+    servers = await server.discover_servers()
+    assert len(servers) == 1
+    assert servers[0]["id"] == "test_server"
+    
+    # Cleanup
+    cleanup_task.cancel()
+    try:
+        await cleanup_task
+    except asyncio.CancelledError:
+        pass
+
+@pytest.mark.asyncio
+async def test_registry_server_default_timeout():
+    # Initialize server with default timeout
+    server = RegistryServer(name="test_registry")
+    
+    # Verify default timeout is 60 seconds
+    assert server.server_timeout_seconds == 60
+    
+    # Register a test server
+    await server.register_server(
+        server_id="test_server",
+        name="Test Server",
+        description="Test server for timeout",
+        capabilities=["test"],
+        endpoint="test://endpoint"
+    )
+    
+    # Verify server is registered
+    servers = await server.discover_servers()
+    assert len(servers) == 1 


### PR DESCRIPTION
- Add configurable server timeout to RegistryServer with default of 60s
- Add name parameter to base Server class and implementations
- Add comprehensive tests for timeout functionality
- Update DoodleServer to properly handle name parameter
- Improve cleanup loop to use dynamic sleep intervals

This change enhances server configuration flexibility and improves server management by allowing custom timeout intervals based on deployment needs.

Fixes #13

## Summary by Sourcery

Add configurable server timeout and name parameters to enhance server configuration flexibility and management. Update the RegistryServer to support dynamic timeout settings and improve the cleanup loop. Implement tests to ensure the new timeout functionality works as expected.

New Features:
- Introduce configurable server timeout parameter to RegistryServer with a default value of 60 seconds.
- Add a name parameter to the base Server class and its implementations, allowing for better identification of server instances.

Enhancements:
- Improve the cleanup loop in RegistryServer to use dynamic sleep intervals based on the server timeout setting.

Tests:
- Add comprehensive tests for the new server timeout functionality, including custom timeout settings and heartbeat handling to prevent timeouts.