### PR TITLE
Refactor server timeout validation in RegistryServer constructor

### DIFF
--- a/mcp_registry/server.py
+++ b/mcp_registry/server.py
@@ -33,6 +33,8 @@ class RegistryServer(Server):
 
     def __init__(self, name: str = "registry", server_timeout_seconds: int = 60):
         super().__init__(name=name)
+        if server_timeout_seconds <= 0:
+            raise ValueError("Server timeout must be positive")
         self.servers: Dict[str, RegisteredServer] = {}
         self.logger = logging.getLogger("mcp.registry")
         self._cleanup_task: Optional[asyncio.Task] = None

--- a/tests/test_registry_server.py
+++ b/tests/test_registry_server.py
@@ -270,3 +270,11 @@ async def test_edge_case_heartbeat_timeouts():
     finally:
         cleanup_task.cancel()
 
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timeout", [-1, 0, -0.5])
+async def test_registry_server_invalid_timeout(timeout):
+    """Test that RegistryServer raises ValueError for invalid timeout values."""
+    with pytest.raises(ValueError, match="Server timeout must be positive"):
+        RegistryServer(name="test_registry", server_timeout_seconds=timeout)
+


### PR DESCRIPTION
feat(registry): validate server timeout configuration

Add validation to prevent negative or zero timeout values in RegistryServer
initialization. Includes new parametrized test cases to verify proper error
handling for invalid timeout configurations.

- Add test_registry_server_invalid_timeout test with parametrized values
- Ensure RegistryServer raises ValueError for non-positive timeouts

Fix #21

## Summary by Sourcery

Validate server timeout configuration in the RegistryServer constructor to ensure non-negative and non-zero values, and add corresponding tests to verify error handling for invalid configurations.

New Features:
- Add validation to prevent negative or zero timeout values in RegistryServer initialization.

Tests:
- Introduce a new parametrized test to verify that RegistryServer raises a ValueError for non-positive timeout values.